### PR TITLE
Double transpose

### DIFF
--- a/bitpermute.cpp
+++ b/bitpermute.cpp
@@ -1,5 +1,4 @@
 #include <bitpermute.h>
-#include <bytewrapper.h>
 
 namespace Reorder
 {

--- a/reorder.cpp
+++ b/reorder.cpp
@@ -219,21 +219,21 @@ namespace Reorder
         return nn;
     }
 
-    const char* const get_transposed_matrix(const char * const MAPPED_FILE, const unsigned HEADER, const unsigned ROW_LENGTH, const std::size_t SUBSAMPLED_ROWS)
+    char* get_transposed_matrix(const char * const MAPPED_FILE, const unsigned HEADER, const unsigned ROW_LENGTH, const std::size_t NB_ROWS)
     {
         //Transposed buffer containing concatenated columns
-        char * transposed_matrix = new char[(8*ROW_LENGTH)*(SUBSAMPLED_ROWS/8)];
+        char * transposed_matrix = new char[(8*ROW_LENGTH)*(NB_ROWS/8)];
 
         /**
          * Hamming distance (dH) can be computed like this: dH(A,B) = H(A ^ B) ;; with ^ as XOR symbol, and H as the Hamming weight aka popcount
          * 
-         * SUBSAMPLED_ROWS/8 is the size of a row in the transposed buffer (as rows are now columns, so the width of transposed matrix) ;; /8 to get width in bytes (=in size of char) instead of bits
+         * NB_ROWS/8 is the size of a row in the transposed buffer (as rows are now columns, so the width of transposed matrix) ;; /8 to get width in bytes (=in size of char) instead of bits
          */
 
         //Matrix transposition
-        __sse_trans(reinterpret_cast<const std::uint8_t*>(MAPPED_FILE+HEADER), reinterpret_cast<std::uint8_t*>(transposed_matrix), SUBSAMPLED_ROWS, ROW_LENGTH*8);
+        __sse_trans(reinterpret_cast<const std::uint8_t*>(MAPPED_FILE+HEADER), reinterpret_cast<std::uint8_t*>(transposed_matrix), NB_ROWS, ROW_LENGTH*8);
         
-        return static_cast<const char* const>(transposed_matrix);
+        return transposed_matrix;
     }
 
     //SSE2 implementation of Hamming distance
@@ -363,9 +363,6 @@ namespace Reorder
         const std::size_t FILE_SIZE = lseek(fd, 0, SEEK_END);
         lseek(fd, 0, SEEK_SET);
 
-        //Map file in memory
-        char* mapped_file = (char*)mmap(nullptr, FILE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0);
-
         //Number of matrix columns
         const unsigned COLUMNS = (SAMPLES+7)/8*8;
 
@@ -374,6 +371,9 @@ namespace Reorder
 
         //Number of matrix rows
         const std::size_t NB_ROWS = (FILE_SIZE - HEADER) / ROW_LENGTH;
+
+        //Map file in memory
+        char* mapped_file = (char*)mmap(nullptr, FILE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0);
 
         if(NB_ROWS < subsampled_rows)
             throw std::invalid_argument("Number of subsampled rows can't be greater to the number of rows in the binary matrix. Maybe one of the parameters is wrong ?");
@@ -391,7 +391,7 @@ namespace Reorder
         //Compute distance matrix
         std::cout << "Transpose submatrix from reference submatrix '" << REFERENCE_MATRIX << "\' ... ";
         START_TIMER;
-        const char* const transposed_matrix = get_transposed_matrix(mapped_file, HEADER, ROW_LENGTH, subsampled_rows);
+        char* transposed_matrix = get_transposed_matrix(mapped_file, HEADER, ROW_LENGTH, subsampled_rows);
         END_TIMER;
 
         //Approximate TSP path with double ended Nearest-Neighbor; compute order
@@ -416,25 +416,44 @@ namespace Reorder
         write(fdorder, reinterpret_cast<const char*>(order.data()), sizeof(unsigned)*order.size());
         close(fdorder);
 
+        //Overshoot NB_ROWS to be a multiple of 8
+        const std::size_t OVERSHOOT_NB_ROWS = (NB_ROWS + 7) / 8 * 8;
+
+        //Compute overshooted file size
+        const std::size_t OVERSHOOT_FILE_SIZE = HEADER + OVERSHOOT_NB_ROWS * ROW_LENGTH;
+
         //Reorder all matrices
         for(unsigned i = 0; i < MATRICES.size(); i++)
         {
             std::cout << "Reordering matrix '" << MATRICES[i] << "' " << (i+1) << "/" << MATRICES.size() << " ... " << std::endl;
 
             fd = open(MATRICES[i], O_RDWR);
-            mapped_file = (char*)mmap(nullptr, FILE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            mapped_file = (char*)mmap(nullptr, OVERSHOOT_FILE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+            if(mapped_file == MAP_FAILED)
+                throw std::runtime_error("mmap() failed");
 
             //Tell system that data will be accessed sequentially
-            posix_madvise(mapped_file, FILE_SIZE, POSIX_MADV_SEQUENTIAL);
+            posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_SEQUENTIAL);
+
+            std::cout << "\tTranspose matrix for reordering columns ... ";
+            START_TIMER;
+            transposed_matrix = get_transposed_matrix(mapped_file, HEADER, ROW_LENGTH, OVERSHOOT_NB_ROWS);
+            END_TIMER;
 
             //Reorder matrix columns
             std::cout << "\tReordering matrix columns ... ";
             START_TIMER;
-            reorder_matrix_columns(mapped_file, HEADER, COLUMNS, ROW_LENGTH, NB_ROWS, order);
+            reorder_matrix_rows(transposed_matrix, 0, OVERSHOOT_NB_ROWS/8, ROW_LENGTH*8, order);
             END_TIMER;
 
+            //Transpose back (overshooted rows will be written back in memory mapped overshoot but won't be added to file, that's how mmap works with overshoot memory)
+            __sse_trans(reinterpret_cast<const std::uint8_t*>(transposed_matrix), reinterpret_cast<std::uint8_t*>(mapped_file+HEADER), ROW_LENGTH*8, OVERSHOOT_NB_ROWS);
+
+            delete[] transposed_matrix;
+
             //Unmap file in memory and close file descriptor 
-            munmap(mapped_file, FILE_SIZE);
+            munmap(mapped_file, OVERSHOOT_FILE_SIZE);
             close(fd);
         }
 

--- a/reorder.cpp
+++ b/reorder.cpp
@@ -221,14 +221,10 @@ namespace Reorder
 
     char* get_transposed_matrix(const char * const MAPPED_FILE, const unsigned HEADER, const unsigned ROW_LENGTH, const std::size_t NB_ROWS)
     {
+        //NB_ROWS/8 is the size of a row in the transposed buffer (as rows are now columns, so the width of transposed matrix) ;; /8 to get width in bytes (=in size of char) instead of bits
         //Transposed buffer containing concatenated columns
         char * transposed_matrix = new char[(8*ROW_LENGTH)*(NB_ROWS/8)];
 
-        /**
-         * Hamming distance (dH) can be computed like this: dH(A,B) = H(A ^ B) ;; with ^ as XOR symbol, and H as the Hamming weight aka popcount
-         * 
-         * NB_ROWS/8 is the size of a row in the transposed buffer (as rows are now columns, so the width of transposed matrix) ;; /8 to get width in bytes (=in size of char) instead of bits
-         */
 
         //Matrix transposition
         __sse_trans(reinterpret_cast<const std::uint8_t*>(MAPPED_FILE+HEADER), reinterpret_cast<std::uint8_t*>(transposed_matrix), NB_ROWS, ROW_LENGTH*8);
@@ -434,7 +430,7 @@ namespace Reorder
                 throw std::runtime_error("mmap() failed");
 
 
-            //Tell system that data will be accessed sequentially
+            //Tell system that data will be accessed randomly
             posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_RANDOM);
             
             std::cout << "\tTranspose matrix for reordering columns ... ";
@@ -447,9 +443,6 @@ namespace Reorder
             START_TIMER;
             reorder_matrix_rows(transposed_matrix, 0, OVERSHOOT_NB_ROWS/8, ROW_LENGTH*8, order);
             END_TIMER;
-
-            //Tell system that data will be accessed sequentially
-            posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_RANDOM);
 
             std::cout << "\tTranspose matrix back ... ";
             //Transpose back (overshooted rows will be written back in memory mapped overshoot but won't be added to file, that's how mmap works with overshoot memory)

--- a/reorder.cpp
+++ b/reorder.cpp
@@ -442,7 +442,7 @@ namespace Reorder
             transposed_matrix = get_transposed_matrix(mapped_file, HEADER, ROW_LENGTH, OVERSHOOT_NB_ROWS);
             END_TIMER;
 
-            //Reorder matrix columns
+            //Reorder matrix columns (transposed matrix rows)
             std::cout << "\tReordering matrix columns ... ";
             START_TIMER;
             reorder_matrix_rows(transposed_matrix, 0, OVERSHOOT_NB_ROWS/8, ROW_LENGTH*8, order);
@@ -451,9 +451,11 @@ namespace Reorder
             //Tell system that data will be accessed sequentially
             posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_RANDOM);
 
+            std::cout << "\tTranspose matrix back ... ";
             //Transpose back (overshooted rows will be written back in memory mapped overshoot but won't be added to file, that's how mmap works with overshoot memory)
+            START_TIMER;
             __sse_trans(reinterpret_cast<const std::uint8_t*>(transposed_matrix), reinterpret_cast<std::uint8_t*>(mapped_file+HEADER), ROW_LENGTH*8, OVERSHOOT_NB_ROWS);
-
+            END_TIMER;
             delete[] transposed_matrix;
 
             //Unmap file in memory and close file descriptor 

--- a/reorder.cpp
+++ b/reorder.cpp
@@ -433,9 +433,10 @@ namespace Reorder
             if(mapped_file == MAP_FAILED)
                 throw std::runtime_error("mmap() failed");
 
-            //Tell system that data will be accessed sequentially
-            posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_SEQUENTIAL);
 
+            //Tell system that data will be accessed sequentially
+            posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_RANDOM);
+            
             std::cout << "\tTranspose matrix for reordering columns ... ";
             START_TIMER;
             transposed_matrix = get_transposed_matrix(mapped_file, HEADER, ROW_LENGTH, OVERSHOOT_NB_ROWS);
@@ -446,6 +447,9 @@ namespace Reorder
             START_TIMER;
             reorder_matrix_rows(transposed_matrix, 0, OVERSHOOT_NB_ROWS/8, ROW_LENGTH*8, order);
             END_TIMER;
+
+            //Tell system that data will be accessed sequentially
+            posix_madvise(mapped_file, OVERSHOOT_FILE_SIZE, POSIX_MADV_RANDOM);
 
             //Transpose back (overshooted rows will be written back in memory mapped overshoot but won't be added to file, that's how mmap works with overshoot memory)
             __sse_trans(reinterpret_cast<const std::uint8_t*>(transposed_matrix), reinterpret_cast<std::uint8_t*>(mapped_file+HEADER), ROW_LENGTH*8, OVERSHOOT_NB_ROWS);

--- a/reorder.h
+++ b/reorder.h
@@ -26,7 +26,6 @@
 
 //Bit permutation
 #include <bitpermute.h>
-#include <bytewrapper.h>
 
 namespace Reorder 
 {
@@ -50,7 +49,7 @@ namespace Reorder
     IndexDistance find_closest_vertex(VPTree<unsigned>& VPTREE, const unsigned VERTEX, const std::vector<bool>& ALREADY_ADDED);
         
     //Precall of SSE bitmatrix transposition, return a new buffer (should be free from memory when transposed bitmatrix is no longer needed)
-    const char * const get_transposed_matrix(const char * const MAPPED_FILE, const unsigned HEADER, const unsigned ROW_LENGTH,  const std::size_t SUBSAMPLED_ROWS);
+    char* get_transposed_matrix(const char * const MAPPED_FILE, const unsigned HEADER, const unsigned ROW_LENGTH,  const std::size_t SUBSAMPLED_ROWS);
 
     //SSE hamming distance between two buffers
     size_t hamming_distance(const char* const BUFFER1, const char* const BUFFER2, const size_t LENGTH);


### PR DESCRIPTION
Merge, double transposition and inplace buffer permutation is quicker than bitpacking for reordering columns